### PR TITLE
Commented out route refresh when user clicks on map to get nearby locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Road-Trip-Planner
+# The Ultimate Road Trip Planner
 
 
 ## Description
@@ -20,7 +20,7 @@ The Ultimate Road Trip Planner is an app where we put in a starting location and
 * Bitly API
 
 ## Built With
-* Sublime Text 
+* Sublime 
 * Heroku 
 
 ## Authors

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -399,7 +399,7 @@ $(document).ready(function() {
     });
     markers.push(marker);
 
-    calculateAndDisplayRoute();
+    // calculateAndDisplayRoute();
     if (markers.length > 0) {
       displayPlacesAroundMarker(markers);
       $("a[href='#cities']").click();

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -172,7 +172,7 @@ $(document).ready(function() {
       markers.forEach(function(m) {
 
         if (m.type === "nearby") {
-          var geourl = "https://api.geonames.org/findNearbyPlaceNameJSON?radius=50&lat=" + m.position.lat() + "&lng=" + m.position.lng() + "&cities=cities10000&username=tripstop";
+          var geourl = "http://api.geonames.org/findNearbyPlaceNameJSON?radius=50&lat=" + m.position.lat() + "&lng=" + m.position.lng() + "&cities=cities10000&username=tripstop";
       
           $.ajax({ url: geourl, method: "GET" }).done(function(geoResponse) {
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -172,7 +172,7 @@ $(document).ready(function() {
       markers.forEach(function(m) {
 
         if (m.type === "nearby") {
-          var geourl = "http://api.geonames.org/findNearbyPlaceNameJSON?radius=50&lat=" + m.position.lat() + "&lng=" + m.position.lng() + "&cities=cities10000&username=tripstop";
+          var geourl = "https://api.geonames.org/findNearbyPlaceNameJSON?radius=50&lat=" + m.position.lat() + "&lng=" + m.position.lng() + "&cities=cities10000&username=tripstop";
       
           $.ajax({ url: geourl, method: "GET" }).done(function(geoResponse) {
 


### PR DESCRIPTION
 I made a minor change to the app. If you put in a long distance trip, the zoom level defaults to a very low zoom. Then if you zoom in to an area that you want to explore and click an area to see nearby places, the app zooms you back all the way out to show the full route. This is because we had a call to the function that calculates and displays the route on the map click. I just commented out the call to this function and the map stays where you are when you click on it. I think it's a lot more user friendly this way. It was line 402 that I commented out. You play around with it to see the difference. I moved it to my repo, and did a pull request to master. It is also up on heroku. Remember to use http on heroku (I forgot lol) and do a cache refresh  (ctrl + F5) if you don't see anything different (I had to). Also made a couple of minor changes to the readme, I plan on doing a little more soon. I downloaded the web recorder to make gifs of the site.